### PR TITLE
Use escaped quotes for entrypoint call

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,11 +53,11 @@ runs:
           --name $containerName `
           -v ${env:GITHUB_WORKSPACE}:$containerSrcPath `
           ghcr.io/mthalman/docker-bump-checker:$dockerBumpCheckerVersion `
-          -BaseImage $baseImage `
-          -TargetImage $targetImage `
-          -DockerfilePath $dockerfile `
-          -BaseStageName $baseStage `
-          -Architecture $arch
+          -BaseImage `"$baseImage`" `
+          -TargetImage `"$targetImage`" `
+          -DockerfilePath `"$dockerfile`" `
+          -BaseStageName `"$baseStage`" `
+          -Architecture `"$arch`"
         if ($LASTEXITCODE -ne 0) {
           throw "command failed"
         }


### PR DESCRIPTION
Since these are being passed to a command, a variable value that is empty would get treated like `-BaseStageName -Architecture amd64` instead of `-BaseStageName "" -Architecture amd64`. The args for `docker-bump-checker` need to have escaped quotes in order to account for empty values.